### PR TITLE
Fixes missing libffi include headers during build.

### DIFF
--- a/python36/PKGBUILD
+++ b/python36/PKGBUILD
@@ -42,6 +42,7 @@ build() {
               --with-system-expat \
               --with-dbmliborder=gdbm:ndbm \
               --with-system-libmpdec \
+              --with-system-ffi \
               --enable-loadable-sqlite-extensions \
               --without-ensurepip
 


### PR DESCRIPTION
Adds --with-system-ffi flag to python36 PKGBUILD to ensure complier can find the include files.
Referenced from current python build https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/python.