### PR TITLE
fix decimal module build

### DIFF
--- a/python38/PKGBUILD
+++ b/python38/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=python38
 pkgver=3.8.9
-pkgrel=1
+pkgrel=2
 _pybasever=3.8
 _pymajver=3
 pkgdesc="Major release 3.8 of the Python high-level programming language"
@@ -14,11 +14,19 @@ depends=('expat' 'bzip2' 'gdbm' 'openssl' 'libffi' 'zlib')
 makedepends=('tk' 'sqlite' 'bluez-libs' 'mpdecimal')
 optdepends=('tk: for tkinter' 'sqlite')
 options=('!makeflags')
-source=(https://www.python.org/ftp/python/${pkgver}/Python-${pkgver}.tar.xz)
-sha256sums=('5e391f3ec45da2954419cab0beaefd8be38895ea5ce33577c3ec14940c4b9572')
+source=(
+    https://www.python.org/ftp/python/${pkgver}/Python-${pkgver}.tar.xz
+    mpdecimal-2.5.1.patch
+)
+sha256sums=(
+    '5e391f3ec45da2954419cab0beaefd8be38895ea5ce33577c3ec14940c4b9572'
+    '8eb389be1babe03a0231001dc16dd2d69a3ea0fbf6b8c976a580787e7ff1594c'
+)
 
 prepare() {
   cd "${srcdir}/Python-${pkgver}"
+
+  patch -p1 -i "${srcdir}/mpdecimal-2.5.1.patch"
 
   # FS#23997
   sed -i -e "s|^#.* /usr/local/bin/python|#!/usr/bin/python|" Lib/cgi.py

--- a/python38/mpdecimal-2.5.1.patch
+++ b/python38/mpdecimal-2.5.1.patch
@@ -1,0 +1,45 @@
+From dd436be488bdca2123d12d1e148d85cb6f98be5f Mon Sep 17 00:00:00 2001
+From: Stefan Krah <skrah@bytereef.org>
+Date: Sun, 10 Jan 2021 16:35:48 +0100
+Subject: [PATCH] Portability fixes.
+
+---
+ Modules/_decimal/_decimal.c | 4 ++--
+ setup.py                    | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Modules/_decimal/_decimal.c b/Modules/_decimal/_decimal.c
+index 664d45a90481d..bbd540bc376e2 100644
+--- a/Modules/_decimal/_decimal.c
++++ b/Modules/_decimal/_decimal.c
+@@ -3295,7 +3295,7 @@ dec_format(PyObject *dec, PyObject *args)
+     }
+     else {
+         size_t n = strlen(spec.dot);
+-        if (n > 1 || (n == 1 && !isascii((uchar)spec.dot[0]))) {
++        if (n > 1 || (n == 1 && !isascii((unsigned char)spec.dot[0]))) {
+             /* fix locale dependent non-ascii characters */
+             dot = dotsep_as_utf8(spec.dot);
+             if (dot == NULL) {
+@@ -3304,7 +3304,7 @@ dec_format(PyObject *dec, PyObject *args)
+             spec.dot = PyBytes_AS_STRING(dot);
+         }
+         n = strlen(spec.sep);
+-        if (n > 1 || (n == 1 && !isascii((uchar)spec.sep[0]))) {
++        if (n > 1 || (n == 1 && !isascii((unsigned char)spec.sep[0]))) {
+             /* fix locale dependent non-ascii characters */
+             sep = dotsep_as_utf8(spec.sep);
+             if (sep == NULL) {
+diff --git a/setup.py b/setup.py
+index ddc0bd067d4e4..c547a68664e8c 100644
+--- a/setup.py
++++ b/setup.py
+@@ -2199,7 +2199,7 @@ def detect_decimal(self):
+         undef_macros = []
+         if '--with-system-libmpdec' in sysconfig.get_config_var("CONFIG_ARGS"):
+             include_dirs = []
+-            libraries = [':libmpdec.so.2']
++            libraries = ['mpdec']
+             sources = ['_decimal/_decimal.c']
+             depends = ['_decimal/docstrings.h']
+         else:


### PR DESCRIPTION
The `makepkg` build may be successful, but the decimal module will have failed to build:
```
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -DOPENSSL_NO_SSL2 -march=ivybridge -O2 -pipe -fno-plt -ftree-vectorize -march=ivybridge -O2 -pipe -fno-plt -ftree-vectorize -D_FORTIFY_SOURCE=2 -fPIC -DCONFIG_64=1 -DASM=1 -I./Include -I. -I/usr/local/include -I[..]/.cache/yay/python38/src/Python-3.8.9/Include -I[..]/.cache/yay/python38/src/Python-3.8.9 -c [..]/.cache/yay/python38/src/Python-3.8.9/Modules/_decimal/_decimal.c -o build/temp.linux-x86_64-3.8[..]/.cache/yay/python38/src/Python-3.8.9/Modules/_decimal/_decimal.o
ERROR: ld.so: object 'libfakeroot.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
ERROR: ld.so: object 'libfakeroot.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
ERROR: ld.so: object 'libfakeroot.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
ERROR: ld.so: object 'libfakeroot.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
In file included from ./Include/unicodeobject.h:58,
                 from ./Include/Python.h:97,
                 from [..]/.cache/yay/python38/src/Python-3.8.9/Modules/_decimal/_decimal.c:29:
[..]/.cache/yay/python38/src/Python-3.8.9/Modules/_decimal/_decimal.c: In function ‘dec_format’:
[..]/.cache/yay/python38/src/Python-3.8.9/Modules/_decimal/_decimal.c:3287:43: error: ‘uchar’ undeclared (first use in this function); did you mean ‘u_char’?
 3287 |         if (n > 1 || (n == 1 && !isascii((uchar)spec.dot[0]))) {
      |                                           ^~~~~
[..]/.cache/yay/python38/src/Python-3.8.9/Modules/_decimal/_decimal.c:3287:43: note: each undeclared identifier is reported only once for each function it appears in
[..]/.cache/yay/python38/src/Python-3.8.9/Modules/_decimal/_decimal.c:3287:49: error: expected ‘)’ before ‘spec’
 3287 |         if (n > 1 || (n == 1 && !isascii((uchar)spec.dot[0]))) {
      |                                                 ^~~~
[..]/.cache/yay/python38/src/Python-3.8.9/Modules/_decimal/_decimal.c:3287:34: note: to match this ‘(’
 3287 |         if (n > 1 || (n == 1 && !isascii((uchar)spec.dot[0]))) {
      |                                  ^~~~~~~
[..]/.cache/yay/python38/src/Python-3.8.9/Modules/_decimal/_decimal.c:3296:49: error: expected ‘)’ before ‘spec’
 3296 |         if (n > 1 || (n == 1 && !isascii((uchar)spec.sep[0]))) {
      |                                                 ^~~~
[..]/.cache/yay/python38/src/Python-3.8.9/Modules/_decimal/_decimal.c:3296:34: note: to match this ‘(’
 3296 |         if (n > 1 || (n == 1 && !isascii((uchar)spec.sep[0]))) {
      |                                  ^~~~~~~

The following modules found by detect_modules() in setup.py, have been
built by the Makefile instead, as configured by the Setup files:
_abc                  atexit                pwd
time


Failed to build these modules:
_decimal
```
It's unfortunate that there does not seem to be a way to configure Python's build system to error out when some of its modules fail to build.
