### PR TITLE
[python311] Update to Python 3.11.0a7

### DIFF
--- a/python311/PKGBUILD
+++ b/python311/PKGBUILD
@@ -2,8 +2,8 @@
 # Maintained at https://github.com/rixx/pkgbuilds, feel free to submit patches
 
 pkgname=python311
-pkgver=3.11.0a6
-pkgrel=2
+pkgver=3.11.0a7
+pkgrel=1
 _pyver=3.11.0
 _pybasever=3.11
 _pymajver=3
@@ -15,7 +15,7 @@ depends=('bzip2' 'expat' 'gdbm' 'libffi' 'libnsl' 'libxcrypt' 'openssl' 'zlib')
 makedepends=('bluez-libs' 'mpdecimal' 'gdb')
 optdepends=('sqlite' 'mpdecimal: for decimal' 'xz: for lzma' 'tk: for tkinter')
 source=(https://www.python.org/ftp/python/${_pyver}/Python-${pkgver}.tar.xz)
-sha256sums=('1c53a2ff75879633e30cac29d2aa6b7a010e355b95f0bf9ac691beccf5f9d12a')
+sha256sums=('b7c56dd74c2f472d496b5a8d356bd6ad9ef9b03f26288c3237d3ff698ab03d74')
 validpgpkeys=(
     '0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D'  # Ned Deily (Python release signing key) <nad@python.org>
     'E3FF2839C048B25C084DEBE9B26995E310250568'  # Łukasz Langa (GPG langa.pl) <lukasz@langa.pl>


### PR DESCRIPTION
See https://pythoninsider.blogspot.com/2022/04/the-last-python-311-alpha-3110a7-is.html