### PR TITLE
Apply 16-byte alignment to avoid segfault

### DIFF
--- a/python36/PKGBUILD
+++ b/python36/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=python36
 pkgver=3.6.15
-pkgrel=4
+pkgrel=5
 _pybasever=3.6
 _pymajver=3
 pkgdesc="Major release 3.6 of the Python high-level programming language"
@@ -13,8 +13,8 @@ url="http://www.python.org/"
 depends=('expat' 'bzip2' 'gdbm' 'openssl' 'libffi' 'zlib')
 makedepends=('tk' 'sqlite' 'bluez-libs' 'mpdecimal')
 optdepends=('tk: for tkinter' 'sqlite')
-source=(http://www.python.org/ftp/python/${pkgver}/Python-${pkgver}.tar.xz)
-sha256sums=('6e28d7cdd6dd513dd190e49bca3972e20fcf455090ccf2ef3f1a227614135d91')
+source=(http://www.python.org/ftp/python/${pkgver}/Python-${pkgver}.tar.xz alignment.patch)
+sha256sums=('6e28d7cdd6dd513dd190e49bca3972e20fcf455090ccf2ef3f1a227614135d91' SKIP)
 provides=("python=$pkgver")
 
 prepare() {
@@ -22,6 +22,11 @@ prepare() {
 
   # FS#23997
   sed -i -e "s|^#.* /usr/local/bin/python|#!/usr/bin/python|" Lib/cgi.py
+
+  msg "fix alignment issue (issue27987)"
+  # via https://github.com/pyenv/pyenv/issues/1889
+  # and https://bugs.python.org/file44413/alignment.patch
+  patch -p1 < ../alignment.patch
 
   # Ensure that we are using the system copy of various libraries (expat, zlib and libffi),
   # rather than copies shipped in the tarball

--- a/python36/alignment.patch
+++ b/python36/alignment.patch
@@ -1,0 +1,24 @@
+--- a/Include/objimpl.h
++++ b/Include/objimpl.h
+@@ -250,7 +250,7 @@
+         union _gc_head *gc_prev;
+         Py_ssize_t gc_refs;
+     } gc;
+-    double dummy;  /* force worst-case alignment */
++    long double dummy;  /* force worst-case alignment */
+ } PyGC_Head;
+
+ extern PyGC_Head *_PyGC_generation0;
+--- a/Objects/obmalloc.c
++++ b/Objects/obmalloc.c
+@@ -643,8 +643,8 @@
+  *
+  * You shouldn't change this unless you know what you are doing.
+  */
+-#define ALIGNMENT               8               /* must be 2^N */
+-#define ALIGNMENT_SHIFT         3
++#define ALIGNMENT               16               /* must be 2^N */
++#define ALIGNMENT_SHIFT         4
+
+ /* Return the number of bytes in size class I, as a uint. */
+ #define INDEX2SIZE(I) (((uint)(I) + 1) << ALIGNMENT_SHIFT)


### PR DESCRIPTION
Repro for segfault is simply `python -c 'import ctypes._endian'` -- I
needed this on x86_64 with gcc 12.1.0.

The most succinct explanation with links is at
https://github.com/pyenv/pyenv/issues/1889#issuecomment-837697366