### PR TITLE
[python311] Update to Python 3.11.0b3

### DIFF
--- a/python311/PKGBUILD
+++ b/python311/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintained at https://github.com/rixx/pkgbuilds, feel free to submit patches
 
 pkgname=python311
-pkgver=3.11.0b2
+pkgver=3.11.0b3
 pkgrel=1
 _pyver=3.11.0
 _pybasever=3.11
@@ -15,7 +15,7 @@ depends=('bzip2' 'expat' 'gdbm' 'libffi' 'libnsl' 'libxcrypt' 'openssl' 'zlib')
 makedepends=('bluez-libs' 'mpdecimal' 'gdb')
 optdepends=('sqlite' 'mpdecimal: for decimal' 'xz: for lzma' 'tk: for tkinter')
 source=(https://www.python.org/ftp/python/${_pyver}/Python-${pkgver}.tar.xz)
-sha256sums=('e574dee6694fb255dff8036f3c0048251e5cb29a167766030b7ce3160fb4c47d')
+sha256sums=('c9b99f5315ea30f8e9fcbce6807a3739e875480d29124e6d9940f6fabcb7c902')
 validpgpkeys=(
     '0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D'  # Ned Deily (Python release signing key) <nad@python.org>
     'E3FF2839C048B25C084DEBE9B26995E310250568'  # Łukasz Langa (GPG langa.pl) <lukasz@langa.pl>


### PR DESCRIPTION
See [Mailman 3 [RELEASE] Expedited release of Python3.11.0b3!! - Python-announce-list - python.org](https://mail.python.org/archives/list/python-announce-list@python.org/thread/YWAX3PNIXA6RDE2CGMGWZBFAAOM2LBA7/)