### PR TITLE
[python312] Update to Python 3.12.0a7

### DIFF
--- a/python312/PKGBUILD
+++ b/python312/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintained at https://github.com/rixx/pkgbuilds, feel free to submit patches
 
 pkgname=python312
-pkgver=3.12.0a6
+pkgver=3.12.0a7
 pkgrel=1
 _pyver=3.12.0
 _pybasever=3.12
@@ -15,7 +15,7 @@ depends=('bzip2' 'expat' 'gdbm' 'libffi' 'libnsl' 'libxcrypt' 'openssl' 'zlib')
 makedepends=('bluez-libs' 'mpdecimal' 'gdb')
 optdepends=('sqlite' 'mpdecimal: for decimal' 'xz: for lzma' 'tk: for tkinter')
 source=(https://www.python.org/ftp/python/${_pyver}/Python-${pkgver}.tar.xz)
-sha256sums=('298440252c4b6b4e120e014c15d729eaf8ab779300dcca61d422c537e4e85eca')
+sha256sums=('a19ae4dc5afebdff5e1312346f160062a11e0dbd5f9e68a6a981ea37b21608e1')
 validpgpkeys=(
     '0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D'  # Ned Deily (Python release signing key) <nad@python.org>
     'E3FF2839C048B25C084DEBE9B26995E310250568'  # Łukasz Langa (GPG langa.pl) <lukasz@langa.pl>


### PR DESCRIPTION
seems to be building and running:

```
$ python3.12
Python 3.12.0a7 (main, Apr 11 2023, 12:48:06) [GCC 12.2.1 20230201] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 
```