### PR TITLE
[python312] Update to Python 3.12.0b4

### DIFF
--- a/python312/PKGBUILD
+++ b/python312/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintained at https://github.com/rixx/pkgbuilds, feel free to submit patches
 
 pkgname=python312
-pkgver=3.12.0b3
+pkgver=3.12.0b4
 pkgrel=1
 _pyver=3.12.0
 _pybasever=3.12
@@ -15,7 +15,7 @@ depends=('bzip2' 'expat' 'gdbm' 'libffi' 'libnsl' 'libxcrypt' 'openssl' 'zlib')
 makedepends=('bluez-libs' 'mpdecimal' 'gdb' 'tk')
 optdepends=('sqlite' 'mpdecimal: for decimal' 'xz: for lzma' 'tk: for tkinter')
 source=(https://www.python.org/ftp/python/${_pyver}/Python-${pkgver}.tar.xz)
-sha256sums=('9160c6065e9885b37c2e57865d0bb27fc7e54aaa9c186c761da30d2bddbcc9ee')
+sha256sums=('f05710c36aee5850f5c2769be76b80bf212aec351438fdf8adc20c38c8361fac')
 validpgpkeys=(
     '0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D'  # Ned Deily (Python release signing key) <nad@python.org>
     'E3FF2839C048B25C084DEBE9B26995E310250568'  # Łukasz Langa (GPG langa.pl) <lukasz@langa.pl>


### PR DESCRIPTION
See [Python 3.12.0 beta 4 released - Core Development - Discussions on Python.org](https://discuss.python.org/t/python-3-12-0-beta-4-released/29492)