### PR TITLE
[python*] `Modules/zlib` was removed in Python 3.7

### DIFF
--- a/python310/PKGBUILD
+++ b/python310/PKGBUILD
@@ -30,7 +30,6 @@ prepare() {
   # Ensure that we are using the system copy of various libraries (expat, zlib and libffi),
   # rather than copies shipped in the tarball
   rm -rf Modules/expat
-  rm -rf Modules/zlib
   rm -rf Modules/_ctypes/{darwin,libffi}*
   rm -rf Modules/_decimal/libmpdec
 }

--- a/python311/PKGBUILD
+++ b/python311/PKGBUILD
@@ -30,7 +30,6 @@ prepare() {
   # Ensure that we are using the system copy of various libraries (expat, zlib and libffi),
   # rather than copies shipped in the tarball
   rm -rf Modules/expat
-  rm -rf Modules/zlib
   rm -rf Modules/_ctypes/{darwin,libffi}*
   rm -rf Modules/_decimal/libmpdec
 }

--- a/python312/PKGBUILD
+++ b/python312/PKGBUILD
@@ -31,7 +31,6 @@ prepare() {
   # Ensure that we are using the system copy of various libraries (expat, zlib and libffi),
   # rather than copies shipped in the tarball
   rm -rf Modules/expat
-  rm -rf Modules/zlib
   rm -rf Modules/_ctypes/libffi*
   rm -rf Modules/_decimal/libmpdec
 }

--- a/python38/PKGBUILD
+++ b/python38/PKGBUILD
@@ -35,7 +35,6 @@ prepare() {
   # Ensure that we are using the system copy of various libraries (expat, zlib and libffi),
   # rather than copies shipped in the tarball
   rm -rf Modules/expat
-  rm -rf Modules/zlib
   rm -rf Modules/_ctypes/{darwin,libffi}*
   rm -rf Modules/_decimal/libmpdec
 }

--- a/python39/PKGBUILD
+++ b/python39/PKGBUILD
@@ -38,7 +38,6 @@ prepare() {
   # Ensure that we are using the system copy of various libraries (expat, zlib and libffi),
   # rather than copies shipped in the tarball
   rm -rf Modules/expat
-  rm -rf Modules/zlib
   rm -rf Modules/_ctypes/{darwin,libffi}*
   rm -rf Modules/_decimal/libmpdec
 }


### PR DESCRIPTION
See https://github.com/python/cpython/commit/d01db1c2a2a71455163a1d3b214cc8dc27201303