### PR TITLE
New alpha published for python 3.13

### DIFF
--- a/python313/PKGBUILD
+++ b/python313/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintained at https://github.com/rixx/pkgbuilds, feel free to submit patches
 
 pkgname=python313
-pkgver=3.13.0a2
+pkgver=3.13.0a3
 pkgrel=3
 _pyver=3.13.0
 _pybasever=3.13
@@ -15,7 +15,7 @@ depends=('bzip2' 'expat' 'gdbm' 'libffi' 'libnsl' 'libxcrypt' 'openssl' 'zlib')
 makedepends=('bluez-libs' 'mpdecimal' 'gdb')
 optdepends=('sqlite' 'mpdecimal: for decimal' 'xz: for lzma' 'tk: for tkinter')
 source=(https://www.python.org/ftp/python/${_pyver}/Python-${pkgver}.tar.xz)
-sha256sums=('b6d46b44190c4c02421eb69a042d16b0c55481bdda818c6c416dc244113a9c2d')
+sha256sums=('20784c8304eb1c69c80f966ebdf0775be2e37e23df3b62461eec12a85dcf7ead')
 validpgpkeys=(
     '0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D'  # Ned Deily (Python release signing key) <nad@python.org>
     'E3FF2839C048B25C084DEBE9B26995E310250568'  # Łukasz Langa (GPG langa.pl) <lukasz@langa.pl>


### PR DESCRIPTION
Cursory tests shows the build recipe is the same and the binary works.