### PR TITLE
add  `-fno-omit-frame-pointer`, `-mno-omit-leaf-frame-pointer`

### DIFF
--- a/python312/PKGBUILD
+++ b/python312/PKGBUILD
@@ -35,7 +35,7 @@ prepare() {
 build() {
   cd "${srcdir}/Python-${pkgver}"
 
-  CFLAGS="${CFLAGS} -fno-semantic-interposition"
+  CFLAGS="${CFLAGS} -fno-semantic-interposition -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
   ./configure --prefix=/usr \
               --enable-shared \
               --with-computed-gotos \

--- a/python313/PKGBUILD
+++ b/python313/PKGBUILD
@@ -35,7 +35,7 @@ prepare() {
 build() {
   cd "${srcdir}/Python-${pkgver}"
 
-  CFLAGS="${CFLAGS} -fno-semantic-interposition"
+  CFLAGS="${CFLAGS} -fno-semantic-interposition -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
   ./configure --prefix=/usr \
               --enable-shared \
               --with-computed-gotos \


### PR DESCRIPTION
For Python 3.12's perf analysis, [these are recommended flags](https://docs.python.org/3/howto/perf_profiling.html#how-to-obtain-the-best-results).

- There is a proposal (not implemented yet) for CPython to build with those points if `--enable-optimizations` isn't enabled (https://github.com/python/cpython/issues/96174).

- Fedora added those flags system-wide (not only Python) last year, see [here](https://fedoraproject.org/wiki/Changes/fno-omit-frame-pointer) for a summary and [here](https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/OOJDAKTJB5WGMOZRXTUX7FTPFBF3H7WE/) for the (lengthy) discussion.

- Ubuntu [will enable](https://ubuntu.com/blog/ubuntu-performance-engineering-with-frame-pointers-by-default) frame pointers for 24.04, but not for Python:

  > There is a small performance penalty associated with the change, but in cases where the impact is high (such as the Python interpreter), we’ll continue to omit frame pointers until this is addressed.