### PR TITLE
[python310] fix _pymajver

### DIFF
--- a/python310/PKGBUILD
+++ b/python310/PKGBUILD
@@ -3,9 +3,9 @@
 
 pkgname=python310
 pkgver=3.10.13
-pkgrel=1
+pkgrel=2
 _pybasever=3.10
-_pymajver=4
+_pymajver=3
 pkgdesc="Major release 3.10 of the Python high-level programming language"
 arch=('i686' 'x86_64')
 license=('custom')


### PR DESCRIPTION
In commit d46277c2eb1f41344045be830c6b0813648894df, `_pymajver` was bumped by mistake, while `_pymajver` should always be 3.