### PR TITLE
[python313] Update to Python 3.13.0b4

### DIFF
--- a/python313/PKGBUILD
+++ b/python313/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintained at https://github.com/rixx/pkgbuilds, feel free to submit patches
 
 pkgname=python313
-pkgver=3.13.0b3
+pkgver=3.13.0b4
 pkgrel=1
 _pyver=3.13.0
 _pybasever=3.13
@@ -14,11 +14,11 @@ url="https://www.python.org/"
 depends=('bzip2' 'expat' 'gdbm' 'libffi' 'libnsl' 'libxcrypt' 'openssl' 'zlib')
 makedepends=('bluez-libs' 'mpdecimal' 'gdb')
 optdepends=('sqlite' 'mpdecimal: for decimal' 'xz: for lzma' 'tk: for tkinter')
-source=(https://www.python.org/ftp/python/${_pyver}/Python-${pkgver}.tar.xz)
-sha256sums=('3be094ad08b11dc2a065463524239c78dc9f2b342b01dcd4e1e606dbbc5c78a5')
+source=("https://www.python.org/ftp/python/${_pyver}/Python-${pkgver}.tar.xz"{,.asc})
+sha256sums=('b2aa557c3c875233abdaf1b124284e5d50f6bb238d62a8b55f12dc92cea1953f'
+            'SKIP')
 validpgpkeys=(
-    '0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D'  # Ned Deily (Python release signing key) <nad@python.org>
-    'E3FF2839C048B25C084DEBE9B26995E310250568'  # Łukasz Langa (GPG langa.pl) <lukasz@langa.pl>
+    '7169605F62C751356D054A26A821E680E5FA6305'  # Thomas Wouters (3.13 release manager) <thomas@python.org>
 )
 
 prepare() {


### PR DESCRIPTION
Update version and SHA256 sum for the beta 4 release.

I've also added the GPG signature and key since I figure that's good practice, but its up to you if you prefer not to include that.